### PR TITLE
Use AWS Marketplace ECR images in Helm charts

### DIFF
--- a/aktus-ai-platform/charts/aktus-db-manager/values.yaml
+++ b/aktus-ai-platform/charts/aktus-db-manager/values.yaml
@@ -1,6 +1,6 @@
 # aktus-gmp-db-manager/values.yaml
 aktusDatabase:
-  image: 539247452833.dkr.ecr.us-east-1.amazonaws.com/aktus-ai/aktus-database:latest
+  image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/aktus-ai/aktus-ai-platform-aws-marketplace-ecr:database-1.0.0
   imagePullPolicy: Always
   port: 80
   resources:

--- a/aktus-ai-platform/charts/aktus-embedding/values.yaml
+++ b/aktus-ai-platform/charts/aktus-embedding/values.yaml
@@ -1,6 +1,6 @@
 # aktus-embedding-service/values.yaml
 aktusEmbedding:
-  image: 539247452833.dkr.ecr.us-east-1.amazonaws.com/aktus-ai/aktus-embedding:latest
+  image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/aktus-ai/aktus-ai-platform-aws-marketplace-ecr:embedding-1.0.1
   imagePullPolicy: Always
   serviceAccount: aktus-ai-platform-sa
   port: 8080

--- a/aktus-ai-platform/charts/aktus-inference/values.yaml
+++ b/aktus-ai-platform/charts/aktus-inference/values.yaml
@@ -1,6 +1,6 @@
 # service-model-inference/values.yaml
 aktusInference:
-  image: 539247452833.dkr.ecr.us-east-1.amazonaws.com/aktus-ai/aktus-inference:latest 
+  image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/aktus-ai/aktus-ai-platform-aws-marketplace-ecr:inference-1.0.0
   nodeSelector: {}
   affinity:
     nodeAffinity:

--- a/aktus-ai-platform/charts/aktus-knowledge-assistant/values.yaml
+++ b/aktus-ai-platform/charts/aktus-knowledge-assistant/values.yaml
@@ -1,5 +1,5 @@
 aktusKnowledgeAssistant:
-  image: 539247452833.dkr.ecr.us-east-1.amazonaws.com/aktus-ai/finchat:va2
+  image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/aktus-ai/aktus-ai-platform-aws-marketplace-ecr:kda-1.0.0
   imagePullPolicy: Always
   port: 80
   service:

--- a/aktus-ai-platform/charts/aktus-multimodal-data-ingestion/values.yaml
+++ b/aktus-ai-platform/charts/aktus-multimodal-data-ingestion/values.yaml
@@ -1,6 +1,6 @@
 # aktus-multimodal-data-ingestion-service/values.yaml
 aktusMdi:
-  image: 539247452833.dkr.ecr.us-east-1.amazonaws.com/aktus-ai/aktus-mdi:latest
+  image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/aktus-ai/aktus-ai-platform-aws-marketplace-ecr:mdi-1.0.0
   imagePullPolicy: Always
   platform: linux/amd64
   serviceAccount: aktus-ai-platform-sa

--- a/aktus-ai-platform/charts/aktus-research/values.yaml
+++ b/aktus-ai-platform/charts/aktus-research/values.yaml
@@ -1,5 +1,5 @@
 aktusResearch:
-  image: 539247452833.dkr.ecr.us-east-1.amazonaws.com/aktus-ai/aktus-research:latest
+  image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/aktus-ai/aktus-ai-platform-aws-marketplace-ecr:research-1.0.0
   imagePullPolicy: Always
   port: 8080
   service:


### PR DESCRIPTION
### Context and Motivation

We’re preparing for our AWS Marketplace launch and need to migrate all service container images to our dedicated AWS Marketplace ECR account. Previously, our Helm charts pointed at the development ECR account (`539247452833`) and used the `latest` tag (or in one case `finchat:va2`), which can lead to non-deterministic deployments and complicate compliance with marketplace requirements. Pinning to explicit semver tags in the marketplace ECR ensures reproducible, auditable releases.

### Summary of Changes

* **Account Switch**: Updated ECR account from `539247452833` → `709825985650`.
* **Tag Pinning**: Replaced `latest` (and `finchat:va2`) with explicit version tags:

  * `database-1.0.0`
  * `embedding-1.0.1`
  * `inference-1.0.0`
  * `kda-1.0.0`
  * `mdi-1.0.0`
  * `research-1.0.0`
* **Charts Updated**:

  * `aktus-db-manager/values.yaml`
  * `aktus-embedding/values.yaml`
  * `aktus-inference/values.yaml`
  * `aktus-knowledge-assistant/values.yaml`
  * `aktus-multimodal-data-ingestion/values.yaml`
  * `aktus-research/values.yaml`

### Testing

* Ran `helm lint` on all modified charts—no errors.
* Deployed to staging cluster; verified pods pulled new images successfully.
