### PR TITLE
Update Helm charts with new EFS fileSystemId

### DIFF
--- a/aktus-ai-platform/charts/aktus-embedding/values.yaml
+++ b/aktus-ai-platform/charts/aktus-embedding/values.yaml
@@ -22,7 +22,7 @@ aktusEmbedding:
     docProcessing: "/doc_processing"
     
   efs:
-    fileSystemId: "fs-0c47b6858c6a3f483"
+    fileSystemId: "fs-0d4f6da8071634ae0"
     
   resources:
     requests:

--- a/aktus-ai-platform/charts/aktus-inference/values.yaml
+++ b/aktus-ai-platform/charts/aktus-inference/values.yaml
@@ -38,7 +38,7 @@ aktusInference:
     docProcessing: /doc_processing
   
   efs:
-    fileSystemId: "fs-0c47b6858c6a3f483"
+    fileSystemId: "fs-0d4f6da8071634ae0"
 
   resources:
     requests:

--- a/aktus-ai-platform/charts/aktus-multimodal-data-ingestion/values.yaml
+++ b/aktus-ai-platform/charts/aktus-multimodal-data-ingestion/values.yaml
@@ -27,7 +27,7 @@ aktusMdi:
     extractedData: "/extracted_data"
     models: "/models"
   efs:
-    fileSystemId: "fs-0c47b6858c6a3f483"
+    fileSystemId: "fs-0d4f6da8071634ae0"
   
   resources:
     requests:

--- a/aktus-ai-platform/charts/aktus-research/values.yaml
+++ b/aktus-ai-platform/charts/aktus-research/values.yaml
@@ -31,7 +31,7 @@ aktusResearch:
     extractedData: "/extracted_data"
   
   efs:
-    fileSystemId: "fs-0c47b6858c6a3f483"
+    fileSystemId: "fs-0d4f6da8071634ae0"
   
   resources:
     requests:

--- a/aktus-ai-platform/charts/postgres/values.yaml
+++ b/aktus-ai-platform/charts/postgres/values.yaml
@@ -11,7 +11,7 @@ aktusPostgres:
     storageClass: "gp3"
     accessMode: "ReadWriteOnce"
   efs:
-    fileSystemId: "fs-0c47b6858c6a3f483"
+    fileSystemId: "fs-0d4f6da8071634ae0"
   initScripts:
     enabled: true
     configMap: postgres-init

--- a/aktus-ai-platform/charts/qdrant/values.yaml
+++ b/aktus-ai-platform/charts/qdrant/values.yaml
@@ -13,7 +13,7 @@ qdrant:
     accessMode: "ReadWriteOnce"
     subPath: "qdrant-data"
   efs:
-    fileSystemId: "fs-0c47b6858c6a3f483"
+    fileSystemId: "fs-0d4f6da8071634ae0"
   resources:
     requests:
       cpu: "250m"

--- a/aktus-ai-platform/charts/rabbitmq/values.yaml
+++ b/aktus-ai-platform/charts/rabbitmq/values.yaml
@@ -13,4 +13,4 @@ rabbitmq:
     accessMode: ReadWriteMany
     size: 5Gi
   efs:
-    fileSystemId: "fs-0c47b6858c6a3f483"
+    fileSystemId: "fs-0d4f6da8071634ae0"


### PR DESCRIPTION
### Context and Motivation

We recently provisioned a new AWS EFS file system to replace the old one (`fs-0c47b6858c6a3f483`) for better performance and to consolidate storage across environments. All of our microservices and data components (Embedding, Inference, MDI, Research, Postgres, Qdrant, RabbitMQ) need to mount the new filesystem. This PR updates each chart’s `values.yaml` to reference the new EFS ID.

### Summary of Changes

* Replaced `efs.fileSystemId` value in `values.yaml` for:

  * **aktus-embedding**
  * **aktus-inference**
  * **aktus-multimodal-data-ingestion**
  * **aktus-research**
  * **postgres**
  * **qdrant**
  * **rabbitmq**
* Old ID: `fs-0c47b6858c6a3f483`
* New ID: `fs-0d4f6da8071634ae0`

### Detailed Explanation

Each chart’s `efs` section now points to the newly created EFS file system:

```yaml
efs:
  fileSystemId: "fs-0d4f6da8071634ae0"
```

* **How**: A simple find-and-replace across the seven `values.yaml` files. No other configuration changes were required, and no schema or version bumps were needed for the charts.

* **Alternatives Considered**:

  * Parameterizing the FS ID via CI/CD environment variable—deferred for a follow-up to avoid complicating current deployments.

### Testing

1. **Local linting**

   ```bash
   helm lint --with-subcharts*
   ```
